### PR TITLE
added afsz page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -37,6 +37,9 @@
     },
     "sectionTeamwork": {
       "title": "Teamwork"
+    },
+    "sectionAFSZ": {
+      "title": "AFSZ"
     }
   },
   "Members": {
@@ -95,7 +98,8 @@
         "projects": "Projects",
         "members": "Members",
         "contact": "Contact",
-        "courses": "Courses"
+        "courses": "Courses",
+        "afsz": "AFSZ"
       }
     },
     "footer": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -99,7 +99,7 @@
         "members": "Members",
         "contact": "Contact",
         "courses": "Courses",
-        "afsz": "AFSZ"
+        "afsz": "ÁFSZ"
       }
     },
     "footer": {

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -37,6 +37,9 @@
     },
     "sectionTeamwork": {
       "title": "Csapatmunka"
+    },
+    "sectionAFSZ": {
+      "title": "AFSZ"
     }
   },
   "Members": {
@@ -95,7 +98,8 @@
         "projects": "Projektjeink",
         "members": "Csapatunk",
         "contact": "Kapcsolat",
-        "courses": "Tanfolyam"
+        "courses": "Tanfolyam",
+        "afsz": "AFSZ"
       }
     },
     "footer": {

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -99,7 +99,7 @@
         "members": "Csapatunk",
         "contact": "Kapcsolat",
         "courses": "Tanfolyam",
-        "afsz": "AFSZ"
+        "afsz": "Felkérések menete"
       }
     },
     "footer": {

--- a/src/pages/about/afsz.tsx
+++ b/src/pages/about/afsz.tsx
@@ -5,12 +5,13 @@ import Container from '~/components/Container'
 import Layout from '~/components/Layout'
 import { readToken } from '~/lib/sanity.api'
 import { getClient } from '~/lib/sanity.client'
-import { commonSerializer } from '~/utils/serializers/common.serializer'
+import { afszSerializer } from '~/utils/serializers/afsz.serializer'
 
 import { useTranslations } from 'next-intl'
 import { NextSeo } from 'next-seo'
 import { getSiteSection } from '~/lib/queries'
 import { SiteSection } from '~/lib/sanity.types'
+import { afszTocSerializer } from '~/utils/serializers/afsz.toc.serializer'
 import { SharedPageProps } from '../_app'
 
 export const getStaticProps: GetStaticProps<
@@ -58,9 +59,18 @@ export default function AFSZPage(
             Utolsó módosítás: {DatesectionAFSZ}
           </h3>
           <hr className="mb-8 mt-3" />
+          <h2 className="text-4xl font-extrabold leading-none tracking-tight py-4 mt-8">
+            Tartalom
+          </h2>
+          <ul className="mb-8 list-disc list-inside ml-2">
+            <PortableText
+              value={sectionAFSZ?.body ?? []}
+              components={afszTocSerializer}
+            />
+          </ul>
           <PortableText
             value={sectionAFSZ?.body ?? []}
-            components={commonSerializer}
+            components={afszSerializer}
           />
         </section>
       </Container>

--- a/src/pages/about/afsz.tsx
+++ b/src/pages/about/afsz.tsx
@@ -1,0 +1,69 @@
+import { PortableText } from '@portabletext/react'
+import { GetStaticProps, InferGetStaticPropsType } from 'next'
+
+import Container from '~/components/Container'
+import Layout from '~/components/Layout'
+import { readToken } from '~/lib/sanity.api'
+import { getClient } from '~/lib/sanity.client'
+import { commonSerializer } from '~/utils/serializers/common.serializer'
+
+import { useTranslations } from 'next-intl'
+import { NextSeo } from 'next-seo'
+import { getSiteSection } from '~/lib/queries'
+import { SiteSection } from '~/lib/sanity.types'
+import { SharedPageProps } from '../_app'
+
+export const getStaticProps: GetStaticProps<
+  SharedPageProps & {
+    sectionAFSZ?: SiteSection
+  }
+> = async ({ draftMode = false, locale }) => {
+  const client = getClient(draftMode ? { token: readToken } : undefined)
+  const sectionAFSZ = await getSiteSection(client, 'afsz', locale)
+
+  return {
+    props: {
+      draftMode,
+      token: draftMode ? readToken : '',
+      sectionAFSZ,
+      messages: (await import(`../../../messages/${locale}.json`)).default,
+    },
+  }
+}
+
+export default function AFSZPage(
+  props: InferGetStaticPropsType<typeof getStaticProps>,
+) {
+  const { sectionAFSZ } = props
+  const t = useTranslations('History')
+  const DatesectionAFSZ = new Date(
+    sectionAFSZ?._updatedAt || '',
+  ).toLocaleDateString('hu-HU', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+  return (
+    <Layout>
+      <NextSeo title="AFSZ" />
+      <Container useCustom>
+        <section className="my-8">
+          <h2 className="text-4xl font-extrabold leading-none tracking-tight mt-16">
+            Általános Felkérési Szabályzat
+          </h2>
+          <h3 className="text-2xl font-semibold leading-none tracking-tight mt-16">
+            Érvényes: 2024. májustól
+          </h3>
+          <h3 className="text-2xl font-semibold leading-none tracking-tight mt-2">
+            Utolsó módosítás: {DatesectionAFSZ}
+          </h3>
+          <hr className="mb-8 mt-3" />
+          <PortableText
+            value={sectionAFSZ?.body ?? []}
+            components={commonSerializer}
+          />
+        </section>
+      </Container>
+    </Layout>
+  )
+}

--- a/src/pages/about/afsz/cmsch.tsx
+++ b/src/pages/about/afsz/cmsch.tsx
@@ -1,0 +1,70 @@
+import { PortableText } from '@portabletext/react'
+import { GetStaticProps, InferGetStaticPropsType } from 'next'
+
+import Container from '~/components/Container'
+import Layout from '~/components/Layout'
+import { readToken } from '~/lib/sanity.api'
+import { getClient } from '~/lib/sanity.client'
+import { afszSerializer } from '~/utils/serializers/afsz.serializer'
+
+import { useTranslations } from 'next-intl'
+import { NextSeo } from 'next-seo'
+import { getSiteSection } from '~/lib/queries'
+import { SiteSection } from '~/lib/sanity.types'
+import { SharedPageProps } from '../../_app'
+
+export const getStaticProps: GetStaticProps<
+  SharedPageProps & {
+    sectionCMSCH?: SiteSection
+  }
+> = async ({ draftMode = false, locale }) => {
+  const client = getClient(draftMode ? { token: readToken } : undefined)
+  const sectionCMSCH = await getSiteSection(client, 'cmsch', locale)
+
+  return {
+    props: {
+      draftMode,
+      token: draftMode ? readToken : '',
+      sectionCMSCH,
+      messages: (await import(`../../../../messages/${locale}.json`)).default,
+    },
+  }
+}
+
+export default function AFSZPage(
+  props: InferGetStaticPropsType<typeof getStaticProps>,
+) {
+  const { sectionCMSCH } = props
+  const t = useTranslations('History')
+  const DatesectionAFSZ = new Date(
+    sectionCMSCH?._updatedAt || '',
+  ).toLocaleDateString('hu-HU', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+  return (
+    <Layout>
+      <NextSeo title="AFSZ" />
+      <Container useCustom>
+        <section className="my-8">
+          <h2 className="text-4xl font-extrabold leading-none tracking-tight mt-16">
+            A CMSCH tartalomkezelő rendszer
+          </h2>
+          <h3 className="text-2xl font-semibold leading-none tracking-tight mt-16">
+            Érvényes: 2024. májustól
+          </h3>
+          <h3 className="text-2xl font-semibold leading-none tracking-tight mt-2">
+            Utolsó módosítás: {DatesectionAFSZ}
+          </h3>
+          <hr className="mb-8 mt-3" />
+          <PortableText
+            value={sectionCMSCH?.body ?? []}
+            components={afszSerializer}
+          />
+        </section>
+        <div></div>
+      </Container>
+    </Layout>
+  )
+}

--- a/src/pages/about/afsz/cmsch.tsx
+++ b/src/pages/about/afsz/cmsch.tsx
@@ -18,7 +18,7 @@ export const getStaticProps: GetStaticProps<
   }
 > = async ({ draftMode = false, locale }) => {
   const client = getClient(draftMode ? { token: readToken } : undefined)
-  const sectionCMSCH = await getSiteSection(client, 'cmsch', locale)
+  const sectionCMSCH = await getSiteSection(client, 'cmsch', 'hu')
 
   return {
     props: {

--- a/src/pages/about/afsz/cmsch.tsx
+++ b/src/pages/about/afsz/cmsch.tsx
@@ -7,7 +7,6 @@ import { readToken } from '~/lib/sanity.api'
 import { getClient } from '~/lib/sanity.client'
 import { afszSerializer } from '~/utils/serializers/afsz.serializer'
 
-import { useTranslations } from 'next-intl'
 import { NextSeo } from 'next-seo'
 import { getSiteSection } from '~/lib/queries'
 import { SiteSection } from '~/lib/sanity.types'
@@ -35,7 +34,6 @@ export default function AFSZPage(
   props: InferGetStaticPropsType<typeof getStaticProps>,
 ) {
   const { sectionCMSCH } = props
-  const t = useTranslations('History')
   const DatesectionAFSZ = new Date(
     sectionCMSCH?._updatedAt || '',
   ).toLocaleDateString('hu-HU', {

--- a/src/pages/about/afsz/general.tsx
+++ b/src/pages/about/afsz/general.tsx
@@ -7,27 +7,29 @@ import { readToken } from '~/lib/sanity.api'
 import { getClient } from '~/lib/sanity.client'
 import { afszSerializer } from '~/utils/serializers/afsz.serializer'
 
-import { useTranslations } from 'next-intl'
 import { NextSeo } from 'next-seo'
 import { getSiteSection } from '~/lib/queries'
 import { SiteSection } from '~/lib/sanity.types'
-import { afszTocSerializer } from '~/utils/serializers/afsz.toc.serializer'
-import { SharedPageProps } from '../_app'
+import { SharedPageProps } from '../../_app'
 
 export const getStaticProps: GetStaticProps<
   SharedPageProps & {
-    sectionAFSZ?: SiteSection
+    sectionGeneral?: SiteSection
   }
 > = async ({ draftMode = false, locale }) => {
   const client = getClient(draftMode ? { token: readToken } : undefined)
-  const sectionAFSZ = await getSiteSection(client, 'afsz', locale)
+  const sectionGeneral = await getSiteSection(
+    client,
+    'general_requests',
+    locale,
+  )
 
   return {
     props: {
       draftMode,
       token: draftMode ? readToken : '',
-      sectionAFSZ,
-      messages: (await import(`../../../messages/${locale}.json`)).default,
+      sectionGeneral,
+      messages: (await import(`../../../../messages/${locale}.json`)).default,
     },
   }
 }
@@ -35,10 +37,9 @@ export const getStaticProps: GetStaticProps<
 export default function AFSZPage(
   props: InferGetStaticPropsType<typeof getStaticProps>,
 ) {
-  const { sectionAFSZ } = props
-  const t = useTranslations('History')
+  const { sectionGeneral } = props
   const DatesectionAFSZ = new Date(
-    sectionAFSZ?._updatedAt || '',
+    sectionGeneral?._updatedAt || '',
   ).toLocaleDateString('hu-HU', {
     year: 'numeric',
     month: 'long',
@@ -50,7 +51,7 @@ export default function AFSZPage(
       <Container useCustom>
         <section className="my-8">
           <h2 className="text-4xl font-extrabold leading-none tracking-tight mt-16">
-            Általános Felkérési Szabályzat
+            Általános weboldal felkérések
           </h2>
           <h3 className="text-2xl font-semibold leading-none tracking-tight mt-16">
             Érvényes: 2024. májustól
@@ -59,20 +60,12 @@ export default function AFSZPage(
             Utolsó módosítás: {DatesectionAFSZ}
           </h3>
           <hr className="mb-8 mt-3" />
-          <h2 className="text-4xl font-extrabold leading-none tracking-tight py-4 mt-8">
-            Tartalom
-          </h2>
-          <ul className="mb-8 list-disc list-inside ml-2">
-            <PortableText
-              value={sectionAFSZ?.body ?? []}
-              components={afszTocSerializer}
-            />
-          </ul>
           <PortableText
-            value={sectionAFSZ?.body ?? []}
+            value={sectionGeneral?.body ?? []}
             components={afszSerializer}
           />
         </section>
+        <div></div>
       </Container>
     </Layout>
   )

--- a/src/pages/about/afsz/general.tsx
+++ b/src/pages/about/afsz/general.tsx
@@ -18,11 +18,7 @@ export const getStaticProps: GetStaticProps<
   }
 > = async ({ draftMode = false, locale }) => {
   const client = getClient(draftMode ? { token: readToken } : undefined)
-  const sectionGeneral = await getSiteSection(
-    client,
-    'general_requests',
-    locale,
-  )
+  const sectionGeneral = await getSiteSection(client, 'general_requests', 'hu')
 
   return {
     props: {

--- a/src/pages/about/afsz/index.tsx
+++ b/src/pages/about/afsz/index.tsx
@@ -1,0 +1,70 @@
+import { PortableText } from '@portabletext/react'
+import { GetStaticProps, InferGetStaticPropsType } from 'next'
+
+import Container from '~/components/Container'
+import Layout from '~/components/Layout'
+import { readToken } from '~/lib/sanity.api'
+import { getClient } from '~/lib/sanity.client'
+import { afszSerializer } from '~/utils/serializers/afsz.serializer'
+
+import { useTranslations } from 'next-intl'
+import { NextSeo } from 'next-seo'
+import { getSiteSection } from '~/lib/queries'
+import { SiteSection } from '~/lib/sanity.types'
+import { SharedPageProps } from '../../_app'
+
+export const getStaticProps: GetStaticProps<
+  SharedPageProps & {
+    sectionAFSZ?: SiteSection
+  }
+> = async ({ draftMode = false, locale }) => {
+  const client = getClient(draftMode ? { token: readToken } : undefined)
+  const sectionAFSZ = await getSiteSection(client, 'afsz', locale)
+
+  return {
+    props: {
+      draftMode,
+      token: draftMode ? readToken : '',
+      sectionAFSZ,
+      messages: (await import(`../../../../messages/${locale}.json`)).default,
+    },
+  }
+}
+
+export default function AFSZPage(
+  props: InferGetStaticPropsType<typeof getStaticProps>,
+) {
+  const { sectionAFSZ } = props
+  const t = useTranslations('History')
+  const DatesectionAFSZ = new Date(
+    sectionAFSZ?._updatedAt || '',
+  ).toLocaleDateString('hu-HU', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+  return (
+    <Layout>
+      <NextSeo title="AFSZ" />
+      <Container useCustom>
+        <section className="my-8">
+          <h2 className="text-4xl font-extrabold leading-none tracking-tight mt-16">
+            Általános Felkérési Szabályzat
+          </h2>
+          <h3 className="text-2xl font-semibold leading-none tracking-tight mt-16">
+            Érvényes: 2024. májustól
+          </h3>
+          <h3 className="text-2xl font-semibold leading-none tracking-tight mt-2">
+            Utolsó módosítás: {DatesectionAFSZ}
+          </h3>
+          <hr className="mb-8 mt-3" />
+          <PortableText
+            value={sectionAFSZ?.body ?? []}
+            components={afszSerializer}
+          />
+        </section>
+        <div></div>
+      </Container>
+    </Layout>
+  )
+}

--- a/src/pages/about/afsz/index.tsx
+++ b/src/pages/about/afsz/index.tsx
@@ -19,7 +19,7 @@ export const getStaticProps: GetStaticProps<
   }
 > = async ({ draftMode = false, locale }) => {
   const client = getClient(draftMode ? { token: readToken } : undefined)
-  const sectionAFSZ = await getSiteSection(client, 'afsz', locale)
+  const sectionAFSZ = await getSiteSection(client, 'afsz', 'hu')
 
   return {
     props: {

--- a/src/schemas/blockContent.ts
+++ b/src/schemas/blockContent.ts
@@ -51,7 +51,7 @@ export default defineType({
               {
                 title: 'URL',
                 name: 'href',
-                type: 'url',
+                type: 'string',
               },
             ],
           },

--- a/src/schemas/blockContent.ts
+++ b/src/schemas/blockContent.ts
@@ -51,6 +51,18 @@ export default defineType({
               {
                 title: 'URL',
                 name: 'href',
+                type: 'url',
+              },
+            ],
+          },
+          {
+            title: 'MAILTO',
+            name: 'mail',
+            type: 'object',
+            fields: [
+              {
+                title: 'URL',
+                name: 'href',
                 type: 'string',
               },
             ],

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -59,3 +59,6 @@ html {
     }
   }
 }
+.custom-list ul {
+  padding-left: 10px;
+}

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,6 +1,7 @@
 import {
   BookOpenIcon,
   ChatBubbleOvalLeftEllipsisIcon,
+  DocumentIcon,
   HomeIcon,
   NewspaperIcon,
   RocketLaunchIcon,
@@ -69,6 +70,13 @@ export const allRoutes: { homeRoute: Route; otherRoutes: Route[] } = {
           href: '/about/contact',
           keywords: 'elérhetőségeink, contact, kapcsolat, email, phone',
           icon: ChatBubbleOvalLeftEllipsisIcon,
+        },
+        {
+          key: 'afsz',
+          href: '/about/afsz',
+          keywords:
+            'elérhetőségeink, contact, felkérés, ajánlat, offer, request',
+          icon: DocumentIcon,
         },
       ],
     },

--- a/src/utils/serializers/afsz.serializer.tsx
+++ b/src/utils/serializers/afsz.serializer.tsx
@@ -45,11 +45,18 @@ export const afszSerializer = {
   },
   marks: {
     link: ({ value, children }) => {
-      const url = new URL(value?.href)
-      const isInternal = value?.href?.startsWith(config.canonical)
+      let href = ''
+      let isInternal = true
+      if (!value?.href.startsWith('mailto')) {
+        href = value?.href
+      } else {
+        const url = new URL(value?.href)
+        isInternal = value?.href?.startsWith(config.canonical)
+        href = isInternal ? `${url.pathname}${url.hash}` : value?.href
+      }
       return (
         <UiLink
-          href={isInternal ? `${url.pathname}${url.hash}` : value?.href}
+          href={href}
           isExternal={!isInternal}
           showAnchorIcon={!isInternal}
         >
@@ -59,6 +66,11 @@ export const afszSerializer = {
     },
     strong: ({ children }) => (
       <span className="text-orange-600 font-bold">{children}</span>
+    ),
+    em: ({ children }) => (
+      <em className="italic" id={`szukseges`}>
+        {children}
+      </em>
     ),
   },
 } satisfies Partial<PortableTextReactComponents>

--- a/src/utils/serializers/afsz.serializer.tsx
+++ b/src/utils/serializers/afsz.serializer.tsx
@@ -1,0 +1,60 @@
+import { Link as UiLink } from '@nextui-org/react'
+import { PortableTextReactComponents } from '@portabletext/react'
+import config from 'next-seo.config'
+import { PortableActionButton } from '~/components/ActionButton'
+import PostCodeBlock from '~/components/post-components/PostCodeBlock'
+import PostImage from '~/components/post-components/PostImage'
+
+export const afszSerializer = {
+  types: {
+    code: PostCodeBlock,
+    image: PostImage,
+    actionButton: PortableActionButton,
+  },
+  block: {
+    h1: ({ children }) => (
+      <h1 className="text-6xl font-extrabold leading-none tracking-tight py-4">
+        {children}
+      </h1>
+    ),
+    h2: ({ children }) => (
+      <h2 className="text-4xl font-extrabold leading-none tracking-tight py-4">
+        {children}
+      </h2>
+    ),
+    h3: ({ children, value: { _key } }) => (
+      <h3 className="text-2xl font-bold py-4 mt-8" id={`h${_key}`}>
+        {children}
+      </h3>
+    ),
+    h4: ({ children }) => (
+      <h4 className="text-xl font-bold py-4 mt-4">{children}</h4>
+    ),
+    normal: ({ children }) => <p className="py-2">{children}</p>,
+    blockquote: ({ children }) => (
+      <blockquote className="border-l-4 border-primary border-opacity-50 pl-4 py-1 my-2">
+        {children}
+      </blockquote>
+    ),
+  },
+  list: {
+    bullet: ({ children }) => (
+      <ul className="list-disc list-inside custom-list">{children}</ul>
+    ),
+  },
+  marks: {
+    link: ({ value, children }) => {
+      const url = new URL(value?.href)
+      const isInternal = value?.href?.startsWith(config.canonical)
+      return (
+        <UiLink
+          href={isInternal ? `${url.pathname}${url.hash}` : value?.href}
+          isExternal={!isInternal}
+          showAnchorIcon={!isInternal}
+        >
+          {children}
+        </UiLink>
+      )
+    },
+  },
+} satisfies Partial<PortableTextReactComponents>

--- a/src/utils/serializers/afsz.serializer.tsx
+++ b/src/utils/serializers/afsz.serializer.tsx
@@ -37,6 +37,7 @@ export const afszSerializer = {
       </blockquote>
     ),
   },
+
   list: {
     bullet: ({ children }) => (
       <ul className="list-disc list-inside custom-list">{children}</ul>
@@ -56,5 +57,8 @@ export const afszSerializer = {
         </UiLink>
       )
     },
+    strong: ({ children }) => (
+      <span className="text-orange-600 font-bold">{children}</span>
+    ),
   },
 } satisfies Partial<PortableTextReactComponents>

--- a/src/utils/serializers/afsz.toc.serializer.tsx
+++ b/src/utils/serializers/afsz.toc.serializer.tsx
@@ -1,24 +1,13 @@
 import { Link } from '@nextui-org/react'
 import { PortableTextReactComponents } from '@portabletext/react'
+import { paddingCalculator, tocSerializer } from './toc.serializer'
 
-export const paddingCalculator = (style: 'h2' | 'h3' | 'h4') => {
-  switch (style) {
-    case 'h2':
-      return 'pl-4'
-    case 'h3':
-      return 'pl-8'
-    case 'h4':
-      return 'pl-12'
-    default:
-      return 'pl-0'
-  }
-}
-
-export const tocSerializer = {
+export const afszTocSerializer = {
   types: {
+    ...tocSerializer.types,
     block: ({ value }) => {
       const { style, _key, children } = value
-      return /^h\d/.test(style ?? 'normal') ? (
+      return /^h3/.test(style ?? 'normal') ? (
         <li className={paddingCalculator(style)}>
           <Link href={`#h${_key}`}>
             {children.map((child) => child.text).join('')}
@@ -26,12 +15,6 @@ export const tocSerializer = {
         </li>
       ) : null
     },
-
-    // ignore other block types
-    code: () => null,
-    image: () => null,
-    actionButton: () => null,
-    youtubeEmbed: () => null,
   },
   list: () => null,
   marks: {},


### PR DESCRIPTION
Well, i still have some questions. Even if i use multilayered bulleted lists in the sanity site section, it shows up as having a uniform indetation.
It would be cool, if we could have autoscroll to the referenced section when a user clicks a given word. Is it possible with code blocks?
Also should this page even be visible for english users? Its not like we are gonna get international requests.